### PR TITLE
Fix build tag for WASI

### DIFF
--- a/main_unix.go
+++ b/main_unix.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris
+//go:build unix || js || wasip1
 
 package pluginrpc
 


### PR DESCRIPTION
Changes the build tag exclusion for unix to include wasip1 arch to fix builds for WASM. Replaces the list of build tags with the shorthand unix for most other platforms.