### PR TITLE
Customize help text and add ServerWithDoc

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -90,6 +90,7 @@ func getFlagUsage(flagSet *pflag.FlagSet, spec Spec, doc string) string {
 	}
 	_, _ = sb.WriteString("\nFlags:\n\n")
 	_, _ = sb.WriteString(flagSet.FlagUsagesWrapped(flagWrapping))
+	_, _ = sb.WriteString("  -h, --help            Show this help.\n")
 	return sb.String()
 }
 

--- a/flags.go
+++ b/flags.go
@@ -17,6 +17,7 @@ package pluginrpc
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -79,13 +80,20 @@ func getFlagUsage(flagSet *pflag.FlagSet, spec Spec, doc string) string {
 		_, _ = sb.WriteString("\n\n")
 	}
 	_, _ = sb.WriteString("Commands:\n\n")
+	var argBasedProcedureStrings []string
+	var pathBasedProcedureStrings []string
 	for _, procedure := range spec.Procedures() {
-		_, _ = sb.WriteString("  ")
 		if args := procedure.Args(); len(args) > 0 {
-			_, _ = sb.WriteString(strings.Join(args, " "))
+			argBasedProcedureStrings = append(argBasedProcedureStrings, strings.Join(args, " "))
 		} else {
-			_, _ = sb.WriteString(procedure.Path())
+			pathBasedProcedureStrings = append(pathBasedProcedureStrings, procedure.Path())
 		}
+	}
+	sort.Strings(argBasedProcedureStrings)
+	sort.Strings(pathBasedProcedureStrings)
+	for _, procedureString := range append(argBasedProcedureStrings, pathBasedProcedureStrings...) {
+		_, _ = sb.WriteString("  ")
+		_, _ = sb.WriteString(procedureString)
 		_, _ = sb.WriteString("\n")
 	}
 	_, _ = sb.WriteString("\nFlags:\n\n")

--- a/internal/example/cmd/echo-plugin/main.go
+++ b/internal/example/cmd/echo-plugin/main.go
@@ -49,7 +49,11 @@ func newServer() (pluginrpc.Server, error) {
 	serverRegistrar := pluginrpc.NewServerRegistrar()
 	echoServiceServer := examplev1pluginrpc.NewEchoServiceServer(pluginrpc.NewHandler(spec), echoServiceHandler{})
 	examplev1pluginrpc.RegisterEchoServiceServer(serverRegistrar, echoServiceServer)
-	return pluginrpc.NewServer(spec, serverRegistrar)
+	return pluginrpc.NewServer(
+		spec,
+		serverRegistrar,
+		pluginrpc.ServerWithDoc("An example plugin that implements the EchoService."),
+	)
 }
 
 type echoServiceHandler struct{}


### PR DESCRIPTION
For example with https://github.com/pluginrpc/pluginrpc-go/blob/main/internal/example/cmd/echo-plugin/main.go:

```
An example plugin that implements the EchoService.

Commands:

  echo error
  echo request
  /pluginrpc.example.v1.EchoService/EchoList

Flags:

      --format string   The format to use for requests, responses, and specs. Must be one of ["binary", "json"]. (default "binary")
      --protocol        Print the protocol to stdout and exit.
      --spec            Print the spec to stdout in the specified format and exit.
  -h, --help            Show this help.
```